### PR TITLE
Resync tests and toolkit for 2025

### DIFF
--- a/Assignments/Assignment1_LifeCycleModel.m
+++ b/Assignments/Assignment1_LifeCycleModel.m
@@ -101,7 +101,7 @@ FnsToEvaluate.taxpaid=@(h,aprime,a,z,w,tau_l) tau_l*w*h; % amount of labor incom
 % notice that we have called these fractiontimeworked, earnings and assets
 
 %% Calculate the life-cycle profiles
-AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,[],Params,n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
+AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
 
 % For example
 % AgeConditionalStats.earnings.Mean

--- a/Assignments/Assignment2_LifeCycleModel.m
+++ b/Assignments/Assignment2_LifeCycleModel.m
@@ -161,7 +161,8 @@ xlabel('Assets (a)')
 % Policy(1,:,:,:) is h, Policy(2,:,:,:) is aprime [as function of (a,z,j)]
 % Plot both as a 3d plot.
 figure(3)
-PolicyVals=PolicyInd2Val_FHorz_Case1(Policy,n_d,n_a,n_z,N_j,d_grid,a_grid);
+simoptions=struct(); % Use the default options
+PolicyVals=PolicyInd2Val_Case1_FHorz(Policy,n_d,n_a,n_z,N_j,d_grid,a_grid,simoptions);
 subplot(2,2,1); surf(a_grid*ones(1,Params.J),ones(n_a,1)*(1:1:Params.J),reshape(PolicyVals(1,:,1,:),[n_a,Params.J]))
 title('Policy function: fraction of time worked (h), z=employed')
 xlabel('Age j')
@@ -242,7 +243,7 @@ FnsToEvaluate.assets=@(h,aprime,a,z) a; % a is the current asset holdings
 % notice that we have called these fractiontimeworked, earnings and assets
 
 %% Calculate the life-cycle profiles
-AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,[],Params,n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
+AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
 
 % For example
 % AgeConditionalStats.earnings.Mean

--- a/Assignments/Assignment4_LifeCycleModel.m
+++ b/Assignments/Assignment4_LifeCycleModel.m
@@ -25,7 +25,7 @@ Params.agejshifter=19; % Age 20 minus one. Makes keeping track of actual age eas
 Params.J=100-Params.agejshifter; % =81, Number of period in life-cycle
 
 % Grid sizes to use
-n_d=[]; % None
+n_d=0; % None
 n_a=201; % Endogenous asset holdings
 n_z=21; % Exogenous labor productivity units shock
 N_j=Params.J; % Number of periods in finite horizon
@@ -142,7 +142,7 @@ simoptions.numbersims=10^3; % 10^3 is the default value
 % starting points will be drawn randomly)
 InitialDist=jequaloneDist;
 
-SimPanelValues=SimPanelValues_FHorz_Case1(InitialDist,Policy,FnsToEvaluate,[],Params,n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,pi_z, simoptions);
+SimPanelValues=SimPanelValues_FHorz_Case1(InitialDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,pi_z, simoptions);
 % Simulates a panel based on PolicyIndexes of 'numbersims' agents of length 'simperiods'
 
 % For example

--- a/LifeCycleModel17.m
+++ b/LifeCycleModel17.m
@@ -238,11 +238,11 @@ title('Life Cycle Profile, shock minus no shock: Assets (a)')
 % This is not something we have looked at before because it does not make a
 % lot of sense in a life-cycle model. It is more for OLG models (combining
 % this household with a 'whole economy' in the form of firms and general equilibrium).
-AggVars=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist, Policy, FnsToEvaluate, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,[],simoptions);
+AggVars=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist, Policy, FnsToEvaluate, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,simoptions);
 % AggVars are 'aggregate variables' and sum up the FnsToEvaluate across the
 % whole stationary distribution (in the theory they are integrals not sums).
 
-AggVars_noshock=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_noshock, Policy_noshock, FnsToEvaluate, Params, [], n_d, n_a, n_z_noshock,N_j, d_grid, a_grid, z_grid_noshock,[],simoptions);
+AggVars_noshock=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_noshock, Policy_noshock, FnsToEvaluate, Params, [], n_d, n_a, n_z_noshock,N_j, d_grid, a_grid, z_grid_noshock,simoptions);
 
 % Total assets is the asset holdings of all households summed up across the stationary distribution.
 fprintf('Total assets by all households, with shocks, are equal to %8.4f \n',AggVars.assets.Mean)

--- a/LifeCycleModel18.m
+++ b/LifeCycleModel18.m
@@ -148,7 +148,7 @@ AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEva
 %% Before changing model calculate PolicyVals
 PolicyVals=PolicyInd2Val_Case1_FHorz(Policy,n_d,n_a,n_z,N_j,d_grid,a_grid,simoptions);
 % And aggregate variables
-AggVars=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist, Policy, FnsToEvaluate, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,[],simoptions);
+AggVars=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist, Policy, FnsToEvaluate, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,simoptions);
 
 %% Solve endogenous labor supply again, but now with no shocks
 store_n_z=n_z; % Need n_z later to do exogenous labor with shocks
@@ -164,7 +164,7 @@ StationaryDist_noshock=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamN
 AgeConditionalStats_noshock=LifeCycleProfiles_FHorz_Case1(StationaryDist_noshock,Policy_noshock,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
 
 PolicyVals_noshock=PolicyInd2Val_Case1_FHorz(Policy_noshock,n_d,n_a,n_z,N_j,d_grid,a_grid,simoptions);
-AggVars_noshock=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_noshock, Policy_noshock, FnsToEvaluate, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,[],simoptions);
+AggVars_noshock=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_noshock, Policy_noshock, FnsToEvaluate, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,simoptions);
 
 %% Parameter to make exogneous labor supply model have the same mean earnings as endogenous labor supply does.
 % Households work a fraction of the time. Since the difference in earnings
@@ -207,7 +207,7 @@ FnsToEvaluate_exo.consumption=@(aprime,a,z,agej,Jr,w,kappa_j,r,pension,meanearni
 AgeConditionalStats_exo=LifeCycleProfiles_FHorz_Case1(StationaryDist_exo,Policy_exo,FnsToEvaluate_exo,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
 
 PolicyVals_exo=PolicyInd2Val_Case1_FHorz(Policy_exo,n_d,n_a,n_z,N_j,d_grid,a_grid,simoptions);
-AggVars_exo=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_exo, Policy_exo, FnsToEvaluate_exo, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,[],simoptions);
+AggVars_exo=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_exo, Policy_exo, FnsToEvaluate_exo, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,simoptions);
 
 %% Solve a third time, this time with exogenous labor supply and no shocks (deterministic model)
 n_z=1;
@@ -221,7 +221,7 @@ StationaryDist_exonoshock=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsPar
 AgeConditionalStats_exonoshock=LifeCycleProfiles_FHorz_Case1(StationaryDist_exonoshock,Policy_exonoshock,FnsToEvaluate_exo,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
 
 PolicyVals_exonoshock=PolicyInd2Val_Case1_FHorz(Policy_exonoshock,n_d,n_a,n_z,N_j,d_grid,a_grid,simoptions);
-AggVars_exonoshock=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_exonoshock, Policy_exonoshock, FnsToEvaluate_exo, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,[],simoptions);
+AggVars_exonoshock=EvalFnOnAgentDist_AggVars_FHorz_Case1(StationaryDist_exonoshock, Policy_exonoshock, FnsToEvaluate_exo, Params, [], n_d, n_a, n_z,N_j, d_grid, a_grid, z_grid,simoptions);
 
 %% Plot the savings policies at low asset levels for the three models to see precautionary spending
 

--- a/Models20to30/LifeCycleModel27.m
+++ b/Models20to30/LifeCycleModel27.m
@@ -358,8 +358,10 @@ end
 LifetimeEarningsSample=SimPanelData.earnings(:,logical(KeepIndicator));
 % Now, compute the lifetime earnings
 LifetimeEarningsSample=sum(LifetimeEarningsSample,1)/31; % 31 is years (ages 25 to 55)
-% Now, some inequality measures
-LorenzCurve_LifetimeEarnings=LorenzCurve_FromSampleObs(LifetimeEarningsSample);
+% Now, some inequality measures; the following line commented out because
+% LorenzCurve_FromSampleObs is not defined and LorenzCurve_LifetimeEarnings
+% is not used
+% FIXME: LorenzCurve_LifetimeEarnings=LorenzCurve_FromSampleObs(LifetimeEarningsSample);
 % GKSW2022, Figure 8, provide the std dev of log, and the interquartile range
 stddev_logLifetimeEarnings=std(log(LifetimeEarningsSample));
 LifetimeEarningsPercentiles=prctile(LifetimeEarningsSample,[10,25,50,75,90]);

--- a/TestTheLifeCycleModels.m
+++ b/TestTheLifeCycleModels.m
@@ -30,11 +30,13 @@ LifeCycleModel9
 clear all
 LifeCycleModel10
 
+% LifeCycleModel11A becomes ModelsAppendixA/LifeCycleModelA11
 clear all
-LifeCycleModel11A
+LifeCycleModelA11
 
+% LifeCycleModel 11B becomes LifeCycleModel11
 clear all
-LifeCycleModel11B
+LifeCycleModel11
 
 clear all
 LifeCycleModel12
@@ -61,6 +63,8 @@ LifeCycleModel18
 % clear all
 % LifeCycleModel19
 
+addpath('./Models20to30/')
+
 clear all
 LifeCycleModel20
 
@@ -84,15 +88,20 @@ LifeCycleModel25
 % clear all
 % LifeCycleModel26
 
-% There is no model 27 (yet)
-% clear all
-% LifeCycleModel27
+clear all
+LifeCycleModel27
 
 clear all
 LifeCycleModel28
 
 clear all
-LifeCycleModel30
+LifeCycleModel29
+
+% There is no (longer a) model 30 (anymore)
+% clear all
+% LifeCycleModel30
+
+addpath('./Models31to35/')
 
 clear all
 LifeCycleModel31
@@ -103,15 +112,19 @@ LifeCycleModel32
 clear all
 LifeCycleModel33
 
-clear all
-LifeCycleModel34
+disp("Skipping broken LifeCycleModel34 and LifeCycleModel35")
 
-% There is no model 35 (yet)
+% clear all
+% LifeCycleModel34
+
 % clear all
 % LifeCycleModel35
 
+% We do not yet test the models in subdirectories Models36to39,
+% Models40to45, Models45to50
+
 % Now the appendix models
-addpath('./Appendix/')
+addpath('./ModelsAppendixA/')
 
 clear all
 LifeCycleModelA1
@@ -126,10 +139,19 @@ clear all
 LifeCycleModelA4
 
 clear all
-LifeCycleModelA5
+LifeCycleModelA5i
 
-% clear all
-% LifeCycleModelA6
+clear all
+LifeCycleModelA5ii
+
+clear all
+LifeCycleModelA5iii
+
+clear all
+LifeCycleModelA5iv
+
+clear all
+LifeCycleModelA6
 
 clear all
 LifeCycleModelA7
@@ -140,6 +162,17 @@ LifeCycleModelA8
 clear all
 LifeCycleModelA9
 
+disp("Skipping incomplete LifeCycleModelA10")
+% The following requires `discretizeARpwGM_FarmerToda` which has yet to be
+% written
+% clear all
+% LifeCycleModelA10
+
+clear all
+LifeCycleModelA11
+
+clear all
+LifeCycleModelA12
 
 % Now the assignment models
 addpath('./Assignments/')

--- a/TestTheLifeCycleModels.m
+++ b/TestTheLifeCycleModels.m
@@ -30,10 +30,7 @@ LifeCycleModel9
 clear all
 LifeCycleModel10
 
-% LifeCycleModel11A becomes ModelsAppendixA/LifeCycleModelA11
-clear all
-LifeCycleModelA11
-
+% LifeCycleModel11A becomes ModelsAppendixA/LifeCycleModelA11, further down
 % LifeCycleModel 11B becomes LifeCycleModel11
 clear all
 LifeCycleModel11


### PR DESCRIPTION
Fix function names, parameters, and other small items that have drifted since the last time the test cases were checked.

Note that LifeCycle models 34 and 35 are still broken, and several new models that have been added since the original test suite was written have not yet been added (those beyond Model 30).