### PR TITLE
(Re)enable CPU-only for simple LCMs

### DIFF
--- a/LifeCycleModel10.m
+++ b/LifeCycleModel10.m
@@ -102,7 +102,8 @@ ReturnFn=@(aprime,a,z,w,sigma,agej,Jr,pension,r,kappa_j,warmglow1,warmglow2,warm
 
 %% Now solve the value function iteration problem, just to check that things are working before we go to General Equilbrium
 disp('Test ValueFnIter')
-vfoptions=struct(); % Just using the defaults.
+[vfoptions,simoptions]=SetOptionsDefaults(); % Just using the defaults.
+simoptions.agegroupings=1:1:N_j;
 tic;
 [V, Policy]=ValueFnIter_Case1_FHorz(n_d,n_a,n_z,N_j, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, [], vfoptions);
 toc
@@ -157,7 +158,6 @@ xlabel('Assets (a)')
 % Policy(1,:,:,:) is is aprime [as function of (a,z,j)]
 % Plot as a 3d plot, again I arbitrarily choose the median value of z
 figure(3)
-simoptions=struct(); % use defaults
 PolicyVals=PolicyInd2Val_Case1_FHorz(Policy,n_d,n_a,n_z,N_j,d_grid,a_grid,simoptions);
 subplot(1,1,1); surf(a_grid*ones(1,Params.J),ones(n_a,1)*(1:1:Params.J),reshape(PolicyVals(1,:,zind,:),[n_a,Params.J]))
 title('Policy function: next period assets (aprime), median z')
@@ -184,8 +184,11 @@ xlabel('Assets (a)')
 %% Initial distribution of agents at birth (j=1)
 % Before we plot the life-cycle profiles we have to define how agents are
 % at age j=1. We will give them all zero assets.
-jequaloneDist=zeros(n_a,n_z,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist=zeros(n_a,n_z); % Put no households anywhere on grid
 jequaloneDist(1,floor((n_z+1)/2))=1; % All agents start with zero assets, and the median shock
+if vfoptions.parallel>1
+    jequaloneDist=gpuArray(jequaloneDist)
+end
 
 %% We now compute the 'stationary distribution' of households
 % Start with a mass of one at initial age, use the conditional survival

--- a/LifeCycleModel11.m
+++ b/LifeCycleModel11.m
@@ -112,6 +112,7 @@ vfoptions.pi_e=pi_e;
 simoptions.n_e=vfoptions.n_e;
 simoptions.e_grid=vfoptions.e_grid;
 simoptions.pi_e=vfoptions.pi_e;
+[vfoptions,simoptions]=SetOptionsDefaults(vfoptions,simoptions); % Just using the defaults.
 
 % Grid for labour choice
 h_grid=linspace(0,1,n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly

--- a/LifeCycleModel4.m
+++ b/LifeCycleModel4.m
@@ -63,7 +63,8 @@ ReturnFn=@(h,aprime,a,w,sigma,psi,eta,agej,Jr,pension,r)...
 
 %% Now solve the value function iteration problem, just to check that things are working before we go to General Equilbrium
 disp('Test ValueFnIter')
-vfoptions=struct(); % Just using the defaults.
+[vfoptions,simoptions]=SetOptionsDefaults(); % Just using the defaults.
+simoptions.agegroupings=1:1:N_j;
 tic;
 [V, Policy]=ValueFnIter_Case1_FHorz(n_d,n_a,n_z,N_j, d_grid, a_grid, [], [], ReturnFn, Params, DiscountFactorParamNames, [], vfoptions);
 toc
@@ -75,7 +76,10 @@ toc
 %% Initial distribution of agents at birth (j=1)
 % Before we plot the life-cycle profiles we have to define how agents are
 % at age j=1. We will give them all zero assets.
-jequaloneDist=zeros(n_a,1,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist=zeros(n_a,1); % Put no households anywhere on grid
+if vfoptions.parallel>1
+    jequaloneDist=gpuArray(jequaloneDist);
+end
 jequaloneDist(1)=1; % Note that 0 is the 1st grid point in the asset grid
 % We have put all the 'new' households (mass of 1) here (zero assets)
 
@@ -86,7 +90,6 @@ jequaloneDist(1)=1; % Note that 0 is the 1st grid point in the asset grid
 % stationary distribution but is actually irrelevant to the life-cycle profiles)
 Params.mewj=ones(1,Params.J)/Params.J; % Put a fraction 1/J at each age
 AgeWeightsParamNames={'mewj'}; % So VFI Toolkit knows which parameter is the mass of agents of each age
-simoptions=struct(); % Use the default options
 StationaryDist=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamNames,Policy,n_d,n_a,n_z,N_j,[],Params,simoptions);
 % Again, we will explain in a later model what the stationary distribution
 % is, it is not important for our current goal of graphing the life-cycle profile
@@ -101,7 +104,7 @@ FnsToEvaluate.assets=@(h,aprime,a) a; % a is the current asset holdings
 % notice that we have called these fractiontimeworked, earnings and assets
 
 %% Calculate the life-cycle profiles
-AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,[],simoptions);
+AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_noz(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,N_j,d_grid,a_grid,simoptions);
 
 % For example
 % AgeConditionalStats.earnings.Mean

--- a/LifeCycleModel6.m
+++ b/LifeCycleModel6.m
@@ -79,7 +79,8 @@ ReturnFn=@(h,aprime,a,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j)...
 
 %% Now solve the value function iteration problem, just to check that things are working before we go to General Equilbrium
 disp('Test ValueFnIter')
-vfoptions=struct(); % Just using the defaults.
+[vfoptions,simoptions]=SetOptionsDefaults(); % Just using the defaults.
+simoptions.agegroupings=1:1:N_j;
 tic;
 [V, Policy]=ValueFnIter_Case1_FHorz(n_d,n_a,n_z,N_j, d_grid, a_grid, [], [], ReturnFn, Params, DiscountFactorParamNames, [], vfoptions);
 toc
@@ -89,7 +90,10 @@ toc
 %% Initial distribution of agents at birth (j=1)
 % Before we plot the life-cycle profiles we have to define how agents are
 % at age j=1. We will give them all zero assets.
-jequaloneDist=zeros(n_a,1,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist=zeros(n_a,1); % Put no households anywhere on grid
+if vfoptions.parallel>1
+    jequaloneDist=gpuArray(jequaloneDist);
+end
 jequaloneDist(1)=1; % Note that 0 is the 1st grid point in the asset grid
 % We have put all the 'new' households (mass of 1) here (zero assets)
 
@@ -104,7 +108,6 @@ end
 Params.mewj=Params.mewj./sum(Params.mewj); % Normalize to one
 
 AgeWeightsParamNames={'mewj'}; % So VFI Toolkit knows which parameter is the mass of agents of each age
-simoptions=struct(); % Use the default options
 StationaryDist=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamNames,Policy,n_d,n_a,n_z,N_j,[],Params,simoptions);
 % Again, we will explain in a later model what the stationary distribution
 % is, it is not important for our current goal of graphing the life-cycle profile
@@ -119,7 +122,7 @@ FnsToEvaluate.assets=@(h,aprime,a) a; % a is the current asset holdings
 % notice that we have called these fractiontimeworked, earnings and assets
 
 %% Calculate the life-cycle profiles
-AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,[],simoptions);
+AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_noz(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,N_j,d_grid,a_grid,simoptions);
 
 % For example
 % AgeConditionalStats.earnings.Mean

--- a/LifeCycleModel7.m
+++ b/LifeCycleModel7.m
@@ -83,7 +83,8 @@ ReturnFn=@(h,aprime,a,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,warmglow1,warmgl
 
 %% Now solve the value function iteration problem, just to check that things are working before we go to General Equilbrium
 disp('Test ValueFnIter')
-vfoptions=struct(); % Just using the defaults.
+[vfoptions,simoptions]=SetOptionsDefaults(); % Just using the defaults.
+simoptions.agegroupings=1:1:N_j;
 tic;
 [V, Policy]=ValueFnIter_Case1_FHorz(n_d,n_a,n_z,N_j, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, [], vfoptions);
 toc
@@ -93,7 +94,10 @@ toc
 %% Initial distribution of agents at birth (j=1)
 % Before we plot the life-cycle profiles we have to define how agents are
 % at age j=1. We will give them all zero assets.
-jequaloneDist=zeros(n_a,1,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist=zeros(n_a,1); % Put no households anywhere on grid
+if vfoptions.parallel>1
+    jequaloneDist=gpuArray(jequaloneDist);
+end
 jequaloneDist(1)=1; % Note that 0 is the 1st grid point in the asset grid
 % We have put all the 'new' households (mass of 1) here (zero assets)
 
@@ -107,7 +111,6 @@ for jj=2:length(Params.mewj)
 end
 Params.mewj=Params.mewj./sum(Params.mewj); % Normalize to one
 AgeWeightsParamNames={'mewj'}; % So VFI Toolkit knows which parameter is the mass of agents of each age
-simoptions=struct(); % Use the default options
 StationaryDist=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamNames,Policy,n_d,n_a,n_z,N_j,pi_z,Params,simoptions);
 % Again, we will explain in a later model what the stationary distribution
 % is, it is not important for our current goal of graphing the life-cycle profile
@@ -122,7 +125,7 @@ FnsToEvaluate.assets=@(h,aprime,a) a; % a is the current asset holdings
 % notice that we have called these fractiontimeworked, earnings and assets
 
 %% Calculate the life-cycle profiles
-AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
+AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_noz(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,N_j,d_grid,a_grid,simoptions);
 
 % For example
 % AgeConditionalStats.earnings.Mean

--- a/LifeCycleModel8.m
+++ b/LifeCycleModel8.m
@@ -103,7 +103,8 @@ ReturnFn=@(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,warmglow1,warm
 
 %% Now solve the value function iteration problem, just to check that things are working before we go to General Equilbrium
 disp('Test ValueFnIter')
-vfoptions=struct(); % Just using the defaults.
+[vfoptions,simoptions]=SetOptionsDefaults(); % Just using the defaults.
+simoptions.agegroupings=1:1:N_j;
 tic;
 [V, Policy]=ValueFnIter_Case1_FHorz(n_d,n_a,n_z,N_j, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, [], vfoptions);
 toc
@@ -166,7 +167,7 @@ xlabel('Assets (a)')
 % Policy(1,:,:,:) is h, Policy(2,:,:,:) is aprime [as function of (a,z,j)]
 % Plot both as a 3d plot.
 figure(3)
-PolicyVals=PolicyInd2Val_Case1_FHorz(Policy,n_d,n_a,n_z,N_j,d_grid,a_grid,[]);
+PolicyVals=PolicyInd2Val_Case1_FHorz(Policy,n_d,n_a,n_z,N_j,d_grid,a_grid,simoptions);
 subplot(2,2,1); surf(a_grid*ones(1,Params.J),ones(n_a,1)*(1:1:Params.J),reshape(PolicyVals(1,:,1,:),[n_a,Params.J]))
 title('Policy function: fraction of time worked (h), z=employed')
 xlabel('Assets (a)')
@@ -219,7 +220,10 @@ xlabel('Assets (a)')
 %% Initial distribution of agents at birth (j=1)
 % Before we plot the life-cycle profiles we have to define how agents are
 % at age j=1. We will give them all zero assets.
-jequaloneDist=zeros(n_a,n_z,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist=zeros(n_a,n_z); % Put no households anywhere on grid
+if vfoptions.parallel>1
+    jequaloneDist=gpuArray(jequaloneDist)
+end
 jequaloneDist(1,floor((n_z+1)/2))=1; % All agents start with zero assets, and the median shock
 
 %% We now compute the 'stationary distribution' of households
@@ -232,7 +236,6 @@ for jj=2:length(Params.mewj)
 end
 Params.mewj=Params.mewj./sum(Params.mewj); % Normalize to one
 AgeWeightsParamNames={'mewj'}; % So VFI Toolkit knows which parameter is the mass of agents of each age
-simoptions=struct(); % Use the default options
 StationaryDist=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamNames,Policy,n_d,n_a,n_z,N_j,pi_z,Params,simoptions);
 % Again, we will explain in a later model what the stationary distribution
 % is, it is not important for our current goal of graphing the life-cycle profile


### PR DESCRIPTION
Several simple LCM models (4, 5, 6, 7) failed to run on CPU-only machines due to greater reliance on `simoptions` being properly initialized.  Several also failed due the trivial case of putting the `jequaloneDist` vector on a (nonexistent) GPU.

The first problem is solved by making it much easier to initialize vfoptions and simoptions to their sensible defaults using a new VFIToolkit-matlab function.  The second is solved by conditionalizing the use of gpuArrays in this one simple case.

Note that while changes have been made for LifeCycleModels 4-11, models 8-10 fail because `LifeCycleProfiles_FHorz_Case1_cpu` references variables that are no longer being passed/computed.  If those can be fixed, these additional cases should work.

Note that LifeCycleModel11 doesn't work because `ValueFnIter_Case1_FHorz` doesn't work with `e` (i.i.d.) variables on CPU-only machines.