### PR TITLE
Re-enable LifeCycleModels 34&35

### DIFF
--- a/TestTheLifeCycleModels.m
+++ b/TestTheLifeCycleModels.m
@@ -109,13 +109,11 @@ LifeCycleModel32
 clear all
 LifeCycleModel33
 
-disp("Skipping broken LifeCycleModel34 and LifeCycleModel35")
+clear all
+LifeCycleModel34
 
-% clear all
-% LifeCycleModel34
-
-% clear all
-% LifeCycleModel35
+clear all
+LifeCycleModel35
 
 % We do not yet test the models in subdirectories Models36to39,
 % Models40to45, Models45to50


### PR DESCRIPTION
With fixes to `ValueFnIter_FHorz_RiskyAsset_EpsteinZin` variants we can now run these tests.