### PR TITLE
Implement ReturnFn for single-precision fp (Model 1)

### DIFF
--- a/LifeCycleModel1.m
+++ b/LifeCycleModel1.m
@@ -37,10 +37,10 @@ Params.w=1; % Wage
 % While there are no 'a' for 'z' in this model, VFI Toolkit requires them 
 % to figure out what is going on. By making them just a single grid point, 
 % and then not using them anywhere, we are essentially solving a model without them.
-a_grid=1;
+a_grid=single(1);
 
 % Grid for labour choice
-h_grid=linspace(0,1,n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
+h_grid=single(linspace(0,1,n_d)'); % Notice that it is imposing the 0<=h<=1 condition implicitly
 % Switch into toolkit notation
 d_grid=h_grid;
 
@@ -66,7 +66,7 @@ DiscountFactorParamNames={'beta'};
 % We then just have to make the @() contain exactly the same inputs as
 % 'LifeCycleModel1_ReturnFn', and then give the parameter names.
 ReturnFn=@(h,aprime,a,w,sigma,psi,eta)...
-    LifeCycleModel1_ReturnFn(h,aprime,a,w,sigma,psi,eta);
+    LifeCycleModel1_ReturnFn_single(h,aprime,a,w,sigma,psi,eta);
 % The first entries must be the decision variables (d), the next period endogenous 
 % state (aprime), and this period endogenous state (a), followed by any parameters.
 % VFI Toolkit will automatically look in 'Params' to find the values of these parameters.

--- a/LifeCycleModel1.m
+++ b/LifeCycleModel1.m
@@ -43,7 +43,7 @@ precision_cast=@(x) single(x)
 a_grid=precision_cast(1);
 
 % Grid for labour choice
-h_grid=linspace(precision_cast(0),precision_cast(1),n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
+h_grid=linspace(precision_cast(0),1,n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
 % Switch into toolkit notation
 d_grid=h_grid;
 

--- a/LifeCycleModel1.m
+++ b/LifeCycleModel1.m
@@ -34,13 +34,16 @@ Params.psi = 10; % Weight on leisure
 Params.w=1; % Wage
 
 %% Grids
+precision='single';
+precision_cast=@(x) single(x)
+
 % While there are no 'a' for 'z' in this model, VFI Toolkit requires them 
 % to figure out what is going on. By making them just a single grid point, 
 % and then not using them anywhere, we are essentially solving a model without them.
-a_grid=single(1);
+a_grid=precision_cast(1);
 
 % Grid for labour choice
-h_grid=linspace(single(0),single(1),n_d)'); % Notice that it is imposing the 0<=h<=1 condition implicitly
+h_grid=linspace(precision_cast(0),precision_cast(1),n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
 % Switch into toolkit notation
 d_grid=h_grid;
 
@@ -65,8 +68,14 @@ DiscountFactorParamNames={'beta'};
 % 'LifeCycleModel1_ReturnFn' (you can right-click on its name below and click 'Open LifeCycleModel1_ReturnFn')
 % We then just have to make the @() contain exactly the same inputs as
 % 'LifeCycleModel1_ReturnFn', and then give the parameter names.
-ReturnFn=@(h,aprime,a,w,sigma,psi,eta)...
-    LifeCycleModel1_ReturnFn_single(h,aprime,a,w,sigma,psi,eta);
+if strcmp(precision,'single')
+    ReturnFn=@(h,aprime,a,w,sigma,psi,eta)...
+        LifeCycleModel1_ReturnFn_single(h,aprime,a,w,sigma,psi,eta);
+else
+    ReturnFn=@(h,aprime,a,w,sigma,psi,eta)...
+        LifeCycleModel1_ReturnFn(h,aprime,a,w,sigma,psi,eta);
+end
+
 % The first entries must be the decision variables (d), the next period endogenous 
 % state (aprime), and this period endogenous state (a), followed by any parameters.
 % VFI Toolkit will automatically look in 'Params' to find the values of these parameters.

--- a/LifeCycleModel1.m
+++ b/LifeCycleModel1.m
@@ -40,7 +40,7 @@ Params.w=1; % Wage
 a_grid=single(1);
 
 % Grid for labour choice
-h_grid=single(linspace(0,1,n_d)'); % Notice that it is imposing the 0<=h<=1 condition implicitly
+h_grid=linspace(single(0),single(1),n_d)'); % Notice that it is imposing the 0<=h<=1 condition implicitly
 % Switch into toolkit notation
 d_grid=h_grid;
 

--- a/LifeCycleModel18.m
+++ b/LifeCycleModel18.m
@@ -82,8 +82,8 @@ Params.wg3=Params.sigma; % By using the same curvature as the utility of consump
 
 
 %% Grids
-precision='double';
-precision_cast=@(x) double(x)
+precision='single';
+precision_cast=@(x) single(x)
 % The ^3 means that there are more points near 0 and near 10. We know from theory that the value function will be more 'curved' near zero assets,
 % and putting more points near curvature (where the derivative changes the most) increases accuracy of results.
 a_grid=precision_cast(10*(linspace(0,1,n_a).^3)'); % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.

--- a/LifeCycleModel18.m
+++ b/LifeCycleModel18.m
@@ -82,18 +82,21 @@ Params.wg3=Params.sigma; % By using the same curvature as the utility of consump
 
 
 %% Grids
+precision='double';
+precision_cast=@(x) double(x)
 % The ^3 means that there are more points near 0 and near 10. We know from theory that the value function will be more 'curved' near zero assets,
 % and putting more points near curvature (where the derivative changes the most) increases accuracy of results.
-a_grid=10*(linspace(0,1,n_a).^3)'; % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
+a_grid=precision_cast(10*(linspace(0,1,n_a).^3)'); % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
 
 % First, the AR(1) process z
 [z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z);
 z_grid=exp(z_grid); % Take exponential of the grid
 [mean_z,~,~,statdist_z]=MarkovChainMoments(z_grid,pi_z); % Calculate the mean of the grid so as can normalise it
-z_grid=z_grid./mean_z; % Normalise the grid on z (so that the mean of z is exactly 1)
+z_grid=precision_cast(z_grid./mean_z); % Normalise the grid on z (so that the mean of z is exactly 1)
+pi_z=precision_cast(pi_z);
 
 % Grid for labour choice
-h_grid=linspace(0,1,n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
+h_grid=linspace(precision_cast(0),precision_cast(1),n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
 % Switch into toolkit notation
 d_grid=h_grid;
 
@@ -101,8 +104,13 @@ d_grid=h_grid;
 DiscountFactorParamNames={'beta','sj'};
 
 % Notice we still use 'LifeCycleModel8_ReturnFn'
-ReturnFn=@(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj) ...
-    LifeCycleModel8_ReturnFn(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj);
+if strcmp(precision,'single')
+    ReturnFn=@(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj)... 
+        LifeCycleModel8_ReturnFn_single(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj);
+else
+    ReturnFn=@(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj)... 
+        LifeCycleModel8_ReturnFn(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj);
+end
 
 %% Solve the value function iteration problem
 disp('Solve for Value fn and Policy fn using ValueFnIter command')
@@ -115,16 +123,16 @@ toc
 
 %% Initial distribution of agents at birth (j=1)
 % Before we plot the life-cycle profiles we have to define how agents are at age j=1. We will give them all zero assets.
-jequaloneDist=zeros([n_a,n_z],'gpuArray'); % Put no households anywhere on grid
-jequaloneDist(1,:)=statdist_z; % All agents start with zero assets, with z drawn from its stationary distribution
+jequaloneDist=zeros([n_a,n_z],precision,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist(1,:)=precision_cast(statdist_z); % All agents start with zero assets, with z drawn from its stationary distribution
 
 %% We now compute the 'stationary distribution' of households
 % Start with a mass of one at initial age, use the conditional survival
 % probabilities sj to calculate the mass of those who survive to next
 % period, repeat. Once done for all ages, normalize to one
-Params.mewj=ones(1,Params.J); % Marginal distribution of households over age
+Params.mewj=ones(1,Params.J,precision); % Marginal distribution of households over age
 for jj=2:length(Params.mewj)
-    Params.mewj(jj)=Params.sj(jj-1)*Params.mewj(jj-1);
+    Params.mewj(jj)=precision_cast(Params.sj(jj-1))*Params.mewj(jj-1);
 end
 Params.mewj=Params.mewj./sum(Params.mewj); % Normalize to one
 AgeWeightsParamNames={'mewj'}; % So VFI Toolkit knows which parameter is the mass of agents of each age
@@ -136,7 +144,12 @@ StationaryDist=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamNames,Pol
 FnsToEvaluate.fractiontimeworked=@(h,aprime,a,z) h; % h is fraction of time worked
 FnsToEvaluate.earnings=@(h,aprime,a,z,w,kappa_j) w*kappa_j*z*h; % w*kappa_j*z*h is the labor earnings (note: h will be zero when z is zero, so could just use w*kappa_j*h)
 FnsToEvaluate.assets=@(h,aprime,a,z) a; % a is the current asset holdings
-FnsToEvaluate.consumption=@(h,aprime,a,z,agej,Jr,w,kappa_j,r,pension) (agej<Jr)*(w*kappa_j*z*h+(1+r)*a-aprime)+(agej>=Jr)*(pension+(1+r)*a-aprime);
+if strcmp(precision,'single')
+    % Cannot nest anonymous function calls
+    FnsToEvaluate.consumption=@(h,aprime,a,z,agej,Jr,w,kappa_j,r,pension) (agej<Jr)*(w*kappa_j*z*h+(single(1)+r)*a-aprime)+(agej>=Jr)*(pension+(single(1)+r)*a-aprime);
+else
+    FnsToEvaluate.consumption=@(h,aprime,a,z,agej,Jr,w,kappa_j,r,pension) (agej<Jr)*(w*kappa_j*z*h+(1+r)*a-aprime)+(agej>=Jr)*(pension+(1+r)*a-aprime);
+end
 
 %% Calculate the life-cycle profiles
 AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
@@ -151,8 +164,8 @@ store_n_z=n_z; % Need n_z later to do exogenous labor with shocks
 n_z=1;
 z_grid=1;
 pi_z=1;
-jequaloneDist=zeros([n_a,n_z],'gpuArray'); % Put no households anywhere on grid
-jequaloneDist(1,1)=1; 
+jequaloneDist=zeros([n_a,n_z],precision,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist(1,1)=precision_cast(1); 
 % ReturnFn is unchanged
 [V_noshock, Policy_noshock]=ValueFnIter_Case1_FHorz(n_d,n_a,n_z,N_j, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, [], vfoptions);
 StationaryDist_noshock=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamNames,Policy_noshock,n_d,n_a,n_z,N_j,pi_z,Params,simoptions);
@@ -184,22 +197,32 @@ n_z=store_n_z;
 [z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z);
 z_grid=exp(z_grid); % Take exponential of the grid
 [mean_z,~,~,statdist_z]=MarkovChainMoments(z_grid,pi_z); % Calculate the mean of the grid so as can normalise it
-z_grid=z_grid./mean_z; % Normalise the grid on z (so that the mean of z is exactly 1)
-jequaloneDist=zeros([n_a,n_z],'gpuArray'); % Put no households anywhere on grid
-jequaloneDist(1,:)=statdist_z; % All agents start with zero assets, with z drawn from its stationary distribution
+z_grid=precision_cast(z_grid./mean_z); % Normalise the grid on z (so that the mean of z is exactly 1)
+pi_z=precision_cast(pi_z);
+jequaloneDist=zeros([n_a,n_z],precision,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist(1,:)=precision_cast(statdist_z); % All agents start with zero assets, with z drawn from its stationary distribution
 
 % Switch to exogenous labor supply
 n_d=0; % None
 d_grid=[]; % No decision variables
 % Change return function
-ReturnFn=@(aprime,a,z,w,sigma,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj,meanearningsratio) ...
-    LifeCycleModel18B_ReturnFn(aprime,a,z,w,sigma,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj,meanearningsratio);
+if strcmp(precision,'single')
+    ReturnFn=@(aprime,a,z,w,sigma,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj,meanearningsratio) ...
+        LifeCycleModel18B_ReturnFn_single(aprime,a,z,w,sigma,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj,meanearningsratio);
+else
+    ReturnFn=@(aprime,a,z,w,sigma,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj,meanearningsratio) ...
+        LifeCycleModel18B_ReturnFn(aprime,a,z,w,sigma,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj,meanearningsratio);
+end
 [V_exo, Policy_exo]=ValueFnIter_Case1_FHorz(n_d,n_a,n_z,N_j, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, [], vfoptions);
 StationaryDist_exo=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamNames,Policy_exo,n_d,n_a,n_z,N_j,pi_z,Params,simoptions);
 % Change FnsToEvaluate
 FnsToEvaluate_exo.earnings=@(aprime,a,z,w,kappa_j,meanearningsratio) meanearningsratio*w*kappa_j*z; % z is the 'stochastic endowment' or 'exogenous earnings'
 FnsToEvaluate_exo.assets=@(aprime,a,z) a; % a is the current asset holdings
-FnsToEvaluate_exo.consumption=@(aprime,a,z,agej,Jr,w,kappa_j,r,pension,meanearningsratio) (agej<Jr)*(meanearningsratio*w*kappa_j*z+(1+r)*a-aprime)+(agej>=Jr)*(pension+(1+r)*a-aprime);
+if strcmp(precision,'single')
+    FnsToEvaluate_exo.consumption=@(aprime,a,z,agej,Jr,w,kappa_j,r,pension,meanearningsratio) (agej<Jr)*(meanearningsratio*w*kappa_j*z+(single(1)+r)*a-aprime)+(agej>=Jr)*(pension+(single(1)+r)*a-aprime);
+else
+    FnsToEvaluate_exo.consumption=@(aprime,a,z,agej,Jr,w,kappa_j,r,pension,meanearningsratio) (agej<Jr)*(meanearningsratio*w*kappa_j*z+(1+r)*a-aprime)+(agej>=Jr)*(pension+(1+r)*a-aprime);
+end
 
 AgeConditionalStats_exo=LifeCycleProfiles_FHorz_Case1(StationaryDist_exo,Policy_exo,FnsToEvaluate_exo,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);
 
@@ -208,10 +231,10 @@ AllStats_exo=EvalFnOnAgentDist_AllStats_FHorz_Case1(StationaryDist_exo, Policy_e
 
 %% Solve a third time, this time with exogenous labor supply and no shocks (deterministic model)
 n_z=1;
-z_grid=1;
-pi_z=1;
-jequaloneDist=zeros([n_a,n_z],'gpuArray'); % Put no households anywhere on grid
-jequaloneDist(1,1)=1; 
+z_grid=precision_cast(1);
+pi_z=precision_cast(1);
+jequaloneDist=zeros([n_a,n_z],precision,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist(1,1)=precision_cast(1); 
 [V_exonoshock, Policy_exonoshock]=ValueFnIter_Case1_FHorz(n_d,n_a,n_z,N_j, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, [], vfoptions);
 StationaryDist_exonoshock=StationaryDist_FHorz_Case1(jequaloneDist,AgeWeightsParamNames,Policy_exonoshock,n_d,n_a,n_z,N_j,pi_z,Params,simoptions);
 % FnsToEvaluate_exo are unchanged

--- a/LifeCycleModel18.m
+++ b/LifeCycleModel18.m
@@ -89,11 +89,12 @@ precision_cast=@(x) single(x)
 a_grid=precision_cast(10*(linspace(0,1,n_a).^3)'); % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
 
 % First, the AR(1) process z
-[z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z);
+farmertodaoptions.precision=precision;
+mcmomentsoptions.precision=precision;
+[z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z,farmertodaoptions);
 z_grid=exp(z_grid); % Take exponential of the grid
-[mean_z,~,~,statdist_z]=MarkovChainMoments(z_grid,pi_z); % Calculate the mean of the grid so as can normalise it
-z_grid=precision_cast(z_grid./mean_z); % Normalise the grid on z (so that the mean of z is exactly 1)
-pi_z=precision_cast(pi_z);
+[mean_z,~,~,statdist_z]=MarkovChainMoments(z_grid,pi_z,mcmomentsoptions); % Calculate the mean of the grid so as can normalise it
+z_grid=z_grid./mean_z; % Normalise the grid on z (so that the mean of z is exactly 1)
 
 % Grid for labour choice
 h_grid=linspace(precision_cast(0),precision_cast(1),n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
@@ -124,7 +125,7 @@ toc
 %% Initial distribution of agents at birth (j=1)
 % Before we plot the life-cycle profiles we have to define how agents are at age j=1. We will give them all zero assets.
 jequaloneDist=zeros([n_a,n_z],precision,'gpuArray'); % Put no households anywhere on grid
-jequaloneDist(1,:)=precision_cast(statdist_z); % All agents start with zero assets, with z drawn from its stationary distribution
+jequaloneDist(1,:)=statdist_z; % All agents start with zero assets, with z drawn from its stationary distribution
 
 %% We now compute the 'stationary distribution' of households
 % Start with a mass of one at initial age, use the conditional survival
@@ -194,11 +195,10 @@ Params.meanearningsratio=0.4767/0.9682;
 %% Solve a second time, but this time with exogenous labor supply
 % Turn shocks back on
 n_z=store_n_z;
-[z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z);
+[z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z,farmertodaoptions);
 z_grid=exp(z_grid); % Take exponential of the grid
-[mean_z,~,~,statdist_z]=MarkovChainMoments(z_grid,pi_z); % Calculate the mean of the grid so as can normalise it
-z_grid=precision_cast(z_grid./mean_z); % Normalise the grid on z (so that the mean of z is exactly 1)
-pi_z=precision_cast(pi_z);
+[mean_z,~,~,statdist_z]=MarkovChainMoments(z_grid,pi_z,mcmomentsoptions); % Calculate the mean of the grid so as can normalise it
+z_grid=z_grid./mean_z; % Normalise the grid on z (so that the mean of z is exactly 1)
 jequaloneDist=zeros([n_a,n_z],precision,'gpuArray'); % Put no households anywhere on grid
 jequaloneDist(1,:)=precision_cast(statdist_z); % All agents start with zero assets, with z drawn from its stationary distribution
 

--- a/LifeCycleModel18B_ReturnFn_single.m
+++ b/LifeCycleModel18B_ReturnFn_single.m
@@ -1,0 +1,29 @@
+function F=LifeCycleModel18B_ReturnFn_single(aprime,a,z,w,sigma,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj,meanearningsratio)
+% The first four are the 'always required' decision variables, next period
+% endogenous states, this period endogenous states, exogenous states
+% After that we need all the parameters the return function uses, it
+% doesn't matter what order we put them here.
+
+F=single(-Inf);
+single_1=single(1);
+if agej<Jr % If working age
+    c=meanearningsratio*w*kappa_j*z+(single_1+r)*a-aprime; % z is stochastic endowment
+else % Retirement
+    c=pension+(single_1+r)*a-aprime;
+end
+
+if c>0
+    F=(c^(single_1-sigma))/(single_1-sigma); % The utility function
+end
+
+% add the warm glow to the return, but only near end of life
+if agej>=Jr+10
+    % Warm glow of bequests: bequest are a luxury good
+    warmglow=wg1*((single_1+aprime/wg2)^(single_1-wg3))/(single_1-wg3);
+    % Modify for beta and sj (get the warm glow next period if die)
+    warmglow=beta*(single_1-sj)*warmglow;
+    % add the warm glow to the return
+    F=F+warmglow;
+end
+
+end

--- a/LifeCycleModel1_ReturnFn_single.m
+++ b/LifeCycleModel1_ReturnFn_single.m
@@ -1,0 +1,23 @@
+function F=LifeCycleModel1_ReturnFn_single(h,aprime,a,w,sigma,psi,eta)
+% In the baseline setup for VFI Toolkit, the first entries are always
+% (i) decision variables, (ii) next period endogenous states, (iii) this 
+% period endogenous states, and (iv) exogenous states.
+% In this model we have 1 decision variable, h, 1 next period endogenous
+% state, aprime, 1 this period endogenous state, a, and 0 exogenous states.
+% Hence, we have (h,aprime,a,...)
+% After that we need all the parameters the return function uses, it
+% doesn't matter what order we put them here.
+
+F=single(-Inf); % -Inf is used as 'never do this'; it is only used if not overwritten below
+
+c=w*h; % This is the budget constraint
+
+% We need to check that consumption is positive, otherwise utility is -Inf
+% (Note that this is already the value of F and will be returned if we
+% don't satisfy c>0)
+if c>0
+    single_1=single(1);
+    F=(c^(single_1-sigma))/(single_1-sigma) -psi*(h^(single_1+eta))/(single_1+eta); % The utility function
+end
+
+end

--- a/LifeCycleModel8.m
+++ b/LifeCycleModel8.m
@@ -77,12 +77,12 @@ precision_cast=@(x) single(x)
 
 % The ^3 means that there are more points near 0 and near 10. We know from theory that the value function will be more 'curved' near zero assets,
 % and putting more points near curvature (where the derivative changes the most) increases accuracy of results.
-a_grid=precision_cast(10*(linspace(0,1,n_a).^3)'); % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
+a_grid=10*(linspace(precision_cast(0),1,n_a).^3)'; % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
 z_grid=precision_cast([1;0]); % the first entry is employment and the second is unemployment.
 pi_z=precision_cast([0.7, 0.3; 0.5, 0.5]); % p_ee=0.7, p_eu=0.3, p_ue=0.5, p_uu=0.5
 
 % Grid for labour choice
-h_grid=linspace(precision_cast(0),precision_cast(1),n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
+h_grid=linspace(precision_cast(0),1,n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
 % Switch into toolkit notation
 d_grid=h_grid;
 

--- a/LifeCycleModel8.m
+++ b/LifeCycleModel8.m
@@ -72,14 +72,15 @@ Params.wg2=3; % degree to which bequests are a luxury good (>=1; =1 would be a n
 Params.wg3=Params.sigma; % By using the same curvature as the utility of consumption it makes it much easier to guess appropriate parameter values for the warm glow
 
 %% Grids
+precision='single';
 % The ^3 means that there are more points near 0 and near 10. We know from theory that the value function will be more 'curved' near zero assets,
 % and putting more points near curvature (where the derivative changes the most) increases accuracy of results.
-a_grid=10*(linspace(0,1,n_a).^3)'; % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
-z_grid=[1;0]; % the first entry is employment and the second is unemployment.
-pi_z=[0.7, 0.3; 0.5, 0.5]; % p_ee=0.7, p_eu=0.3, p_ue=0.5, p_uu=0.5
+a_grid=single(10*(linspace(0,1,n_a).^3)'); % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
+z_grid=single([1;0]); % the first entry is employment and the second is unemployment.
+pi_z=single([0.7, 0.3; 0.5, 0.5]); % p_ee=0.7, p_eu=0.3, p_ue=0.5, p_uu=0.5
 
 % Grid for labour choice
-h_grid=linspace(0,1,n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
+h_grid=linspace(single(0),single(1),n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
 % Switch into toolkit notation
 d_grid=h_grid;
 
@@ -88,7 +89,7 @@ DiscountFactorParamNames={'beta','sj'};
 
 % Notice change to 'LifeCycleModel8_ReturnFn'
 ReturnFn=@(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj)... 
-    LifeCycleModel8_ReturnFn(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj);
+    LifeCycleModel8_ReturnFn_single(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj);
 % Important change: we now have z as the fourth input to the ReturnFn, the
 % action space of our model has increased.
 % The first inputs are always the relevant 'action space' for our model, which in
@@ -216,7 +217,7 @@ xlabel('Assets (a)')
 
 %% Initial distribution of agents at birth (j=1)
 % Before we plot the life-cycle profiles we have to define how agents are at age j=1. We will give them all zero assets.
-jequaloneDist=zeros(n_a,n_z,'gpuArray'); % Put no households anywhere on grid
+jequaloneDist=zeros(n_a,n_z,precision,'gpuArray'); % Put no households anywhere on grid
 jequaloneDist(1,floor((n_z+1)/2))=1; % All agents start with zero assets, and the median shock
 
 %% We now compute the 'stationary distribution' of households

--- a/LifeCycleModel8.m
+++ b/LifeCycleModel8.m
@@ -73,14 +73,16 @@ Params.wg3=Params.sigma; % By using the same curvature as the utility of consump
 
 %% Grids
 precision='single';
+precision_cast=@(x) single(x)
+
 % The ^3 means that there are more points near 0 and near 10. We know from theory that the value function will be more 'curved' near zero assets,
 % and putting more points near curvature (where the derivative changes the most) increases accuracy of results.
-a_grid=single(10*(linspace(0,1,n_a).^3)'); % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
-z_grid=single([1;0]); % the first entry is employment and the second is unemployment.
-pi_z=single([0.7, 0.3; 0.5, 0.5]); % p_ee=0.7, p_eu=0.3, p_ue=0.5, p_uu=0.5
+a_grid=precision_cast(10*(linspace(0,1,n_a).^3)'); % The ^3 means most points are near zero, which is where the derivative of the value fn changes most.
+z_grid=precision_cast([1;0]); % the first entry is employment and the second is unemployment.
+pi_z=precision_cast([0.7, 0.3; 0.5, 0.5]); % p_ee=0.7, p_eu=0.3, p_ue=0.5, p_uu=0.5
 
 % Grid for labour choice
-h_grid=linspace(single(0),single(1),n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
+h_grid=linspace(precision_cast(0),precision_cast(1),n_d)'; % Notice that it is imposing the 0<=h<=1 condition implicitly
 % Switch into toolkit notation
 d_grid=h_grid;
 
@@ -88,8 +90,14 @@ d_grid=h_grid;
 DiscountFactorParamNames={'beta','sj'};
 
 % Notice change to 'LifeCycleModel8_ReturnFn'
-ReturnFn=@(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj)... 
-    LifeCycleModel8_ReturnFn_single(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj);
+if strcmp(precision,'single')
+    ReturnFn=@(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj)... 
+        LifeCycleModel8_ReturnFn_single(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj);
+else
+    ReturnFn=@(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj)... 
+        LifeCycleModel8_ReturnFn(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj);
+end
+
 % Important change: we now have z as the fourth input to the ReturnFn, the
 % action space of our model has increased.
 % The first inputs are always the relevant 'action space' for our model, which in

--- a/LifeCycleModel8_ReturnFn_single.m
+++ b/LifeCycleModel8_ReturnFn_single.m
@@ -1,0 +1,37 @@
+function F=LifeCycleModel8_ReturnFn_single(h,aprime,a,z,w,sigma,psi,eta,agej,Jr,pension,r,kappa_j,wg1,wg2,wg3,beta,sj)
+% In the baseline setup for VFI Toolkit, the first entries are always
+% (i) decision variables, (ii) next period endogenous states, (iii) this 
+% period endogenous states, and (iv) exogenous states.
+% In this model we have 1 decision variable, h, 1 next period endogenous
+% state, aprime, 1 this period endogenous state, a, and 1 markov exogenous state, z.
+% Hence, we have (h,aprime,a,z,...)
+% After that we need all the parameters the return function uses, it
+% doesn't matter what order we put them here.
+
+% Important change: we now have z as the fourth input to the ReturnFn, the
+% space of our model has increased.
+
+F=single(-Inf);
+single_1=single(1);
+
+if agej<Jr % If working age
+    c=w*kappa_j*z*h+(single_1+r)*a-aprime; % Add z here
+else % Retirement
+    c=pension+(single_1+r)*a-aprime;
+end
+
+if c>0
+    F=(c^(single_1-sigma))/(single_1-sigma) -psi*(h^(single_1+eta))/(single_1+eta); % The utility function
+end
+
+% add the warm glow to the return, but only near end of life
+if agej>=Jr+single(10)
+    % Warm glow of bequests: bequest are a luxury good
+    warmglow=wg1*((single_1+aprime/wg2)^(single_1-wg3))/(single_1-wg3);
+    % Modify for beta and sj (get the warm glow next period if die)
+    warmglow=beta*(single_1-sj)*warmglow;
+    % add the warm glow to the return
+    F=F+warmglow;
+end
+
+end

--- a/Models31to35/LifeCycleModel31_aprimeFn_single.m
+++ b/Models31to35/LifeCycleModel31_aprimeFn_single.m
@@ -1,0 +1,10 @@
+function aprime=LifeCycleModel31_aprimeFn_single(riskyshare,savings,u, r)
+% Note: because of how riskyasset works we need to input (d,u,...) as the first arguements.
+% That is, the first inputs must be the decision variables (d variables),
+% followed by the shocks that are iid and occur between periods (u variables)
+% And because we use vfoptions.refine_d, the decision variables for aprimeFn must follow the ordering d2,d3
+
+single_1=single(1);
+aprime=(single_1+r)*(single_1-riskyshare)*savings+(single_1+r+u)*riskyshare*savings;
+
+end

--- a/Models31to35/LifeCycleModel35.m
+++ b/Models31to35/LifeCycleModel35.m
@@ -64,6 +64,13 @@ vfoptions.refine_d=[0,1,1]; % tell the code how many d1, d2, and d3 there are
 % It is possible to solve models without any d1, as is the case here.
 simoptions.refine_d=vfoptions.refine_d;
 
+precision='single';
+if strcmp(precision,'single')
+    precision_cast=@(x) single(x)
+else
+    precision_cast=@(x) double(x)
+end
+
 %% Parameters
 
 % Housing
@@ -89,7 +96,9 @@ Params.r=0.05; % Rate of return on risk free asset
 Params.rp=0.03; % Mean excess returns to the risky asset (so the mean return of the risky asset will be r+rp)
 Params.sigma_u=0.025; % Standard deviation of innovations to the risky asset
 Params.rho_u=0; % Asset return risk component is modeled as iid (if you regress, e.g., the percent change in S&P500 on its one year lag you get a coefficient of essentially zero)
-[u_grid, pi_u]=discretizeAR1_FarmerToda(Params.rp,Params.rho_u,Params.sigma_u,n_u);
+farmertodaoptions.precision=precision;
+mcmomentsoptions.precision=precision;
+[u_grid, pi_u]=discretizeAR1_FarmerToda(Params.rp,Params.rho_u,Params.sigma_u,n_u,farmertodaoptions);
 pi_u=pi_u(1,:)'; % This is iid
 
 % Demographics
@@ -120,31 +129,32 @@ Params.sj=1-Params.dj(21:101); % Conditional survival probabilities
 Params.sj(end)=0; % In the present model the last period (j=J) value of sj is actually irrelevant
 
 %% Grids
+
 % The ^3 means that there are more points near 0 and near 10. We know from theory that the value function will be more 'curved' near zero assets,
 % and putting more points near curvature (where the derivative changes the most) increases accuracy of results.
-asset_grid=-3+13*(linspace(0,1,n_a(2)))'; % Note, I use equal spacing (normally would put most points near zero)
+asset_grid=-3+13*(linspace(precision_cast(0),precision_cast(1),n_a(2)))'; % Note, I use equal spacing (normally would put most points near zero)
 % note: will go from -3 to 13-3
 % Make it so that there is a zero assets
 % Find closest to zero assets
 [~,zeroassetindex]=min(abs(asset_grid));
-asset_grid(zeroassetindex)=0;
+asset_grid(zeroassetindex)=precision_cast(0);
 
 % age20avgincome=Params.w*Params.kappa_j(1);
 % house_grid=[0; logspace(2*age20avgincome, 12*age20avgincome, 5)'];
-house_grid=(0:1:n_a(1)-1)';
+house_grid=(precision_cast(0):n_a(1)-1)';
 % Note, we can see from w*kappa_j*z and the values of these, that average
 % income is going to be around one, so will just use this simpler house grid
 % [We can think about the values of the house_grid as being relative the average income (or specifically average at a given age)]
 Params.minhouse=house_grid(2); % first is zero (no house)
 
 % First, the AR(1) process z
-[z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z);
+[z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z,farmertodaoptions);
 z_grid=exp(z_grid); % Take exponential of the grid
-[mean_z,~,~,~]=MarkovChainMoments(z_grid,pi_z); % Calculate the mean of the grid so as can normalise it
+[mean_z,~,~,~]=MarkovChainMoments(z_grid,pi_z,mcmomentsoptions); % Calculate the mean of the grid so as can normalise it
 z_grid=z_grid./mean_z; % Normalise the grid on z (so that the mean of z is exactly 1)
 
 % Share of assets invested in the risky asset
-riskyshare_grid=linspace(0,1,n_d(1))'; % Share of assets, from 0 to 1
+riskyshare_grid=linspace(precision_cast(0),precision_cast(1),n_d(1))'; % Share of assets, from 0 to 1
 % Set up d for VFI Toolkit (is the two decision variables)
 d_grid=[riskyshare_grid; asset_grid]; % Note: this does not have to be a_grid, I just chose to use same grid for savings as for assets
 
@@ -154,7 +164,11 @@ a_grid=[house_grid; asset_grid];
 
 % riskyasset: aprime_val=aprimeFn(d,u)
 % vfoptions.refine_d: the decision variables input to aprimeFn are d2,d3
-aprimeFn=@(riskyshare,savings,u, r) LifeCycleModel31_aprimeFn(riskyshare,savings, u, r); % Will return the value of aprime
+if strcmp(precision,'single')
+    aprimeFn=@(riskyshare,savings,u, r) LifeCycleModel31_aprimeFn_single(riskyshare,savings, u, r); % Will return the value of aprime
+else
+    aprimeFn=@(riskyshare,savings,u, r) LifeCycleModel31_aprimeFn(riskyshare,savings, u, r); % Will return the value of aprime
+end
 % Note that u is risky asset excess return and effectively includes both the (excess) mean and standard deviation of risky assets
 
 %% Put the risky asset into vfoptions and simoptions
@@ -176,8 +190,13 @@ simoptions.d_grid=d_grid;
 % DiscountFactorParamNames={'beta','sj'};
 
 % Use 'LifeCycleModel35_ReturnFn'
-ReturnFn=@(savings,hprime,h,a,z,w,sigma,agej,Jr,pension,kappa_j,sigma_h,f_htc,minhouse,rentprice,f_coll,houseservices) ...
-    LifeCycleModel35_ReturnFn(savings,hprime,h,a,z,w,sigma,agej,Jr,pension,kappa_j,sigma_h,f_htc,minhouse,rentprice,f_coll,houseservices);
+if strcmp(precision,'single')
+    ReturnFn=@(savings,hprime,h,a,z,w,sigma,agej,Jr,pension,kappa_j,sigma_h,f_htc,minhouse,rentprice,f_coll,houseservices) ...
+        LifeCycleModel35_ReturnFn_single(savings,hprime,h,a,z,w,sigma,agej,Jr,pension,kappa_j,sigma_h,f_htc,minhouse,rentprice,f_coll,houseservices);
+else
+    ReturnFn=@(savings,hprime,h,a,z,w,sigma,agej,Jr,pension,kappa_j,sigma_h,f_htc,minhouse,rentprice,f_coll,houseservices) ...
+        LifeCycleModel35_ReturnFn(savings,hprime,h,a,z,w,sigma,agej,Jr,pension,kappa_j,sigma_h,f_htc,minhouse,rentprice,f_coll,houseservices);
+end
 % vfoptions.refine_d: only (d1,d3,..) are input to ReturnFn [this model has no d1, so here just d3]
 
 %% Solve the value function iteration problem

--- a/Models31to35/LifeCycleModel35_ReturnFn_single.m
+++ b/Models31to35/LifeCycleModel35_ReturnFn_single.m
@@ -1,0 +1,45 @@
+function F=LifeCycleModel35_ReturnFn_single(savings,hprime,h,a,z,w,sigma,agej,Jr,pension,kappa_j,sigma_h,f_htc,minhouse,rentprice,f_coll,houseservices)
+% Note: riskyasset, so first inputs are (d,a,z,...)
+% vfoptions.refine_d: only decisions d1,d3 are input to ReturnFn (and this model has no d1)
+
+% Make buying/selling a house costly/illiquid
+single_0=single(0);
+htc=single_0; % house transaction cost
+if hprime~=h
+    htc=f_htc*(h+hprime);
+end
+
+% Housing services
+if h==0
+    s=single(0.5)*houseservices*minhouse;
+    rentalcosts=rentprice;
+else
+    s=houseservices*h;
+    rentalcosts=single_0;
+end
+
+F=single(-Inf);
+if agej<Jr % If working age
+    c=w*kappa_j*z+a-savings+(h-hprime)-htc-rentalcosts; % Note: +h and -hprime
+else % Retirement
+    c=pension+a-savings+(h-hprime)-htc-rentalcosts; % give a rent subsidy to elderly for no good reason-rentalcosts;
+end
+
+if c>0
+    single_1=single(1);
+    F=(((c^(single_1-sigma_h))*(s^sigma_h))^(single_1-sigma))/(single_1-sigma); % The utility function
+end
+
+if savings<-f_coll*hprime
+    F=single(-Inf); % Collateral constraint on borrowing
+end
+
+% Negative savings is only allowed in the form of a safe mortgage. This is dealt with via the aprimeFn.
+
+%% Ban pensioners from negative assets
+if agej>=Jr && savings<0
+    F=single(-Inf);
+end
+
+
+end

--- a/Models40to44/LifeCycleModel40.m
+++ b/Models40to44/LifeCycleModel40.m
@@ -96,10 +96,17 @@ Params.wg2=3; % degree to which bequests are a luxury good (>=1; =1 would be a n
 Params.wg3=Params.sigma; % By using the same curvature as the utility of consumption it makes it much easier to guess appropriate parameter values for the warm glow
 
 %% Grids
+precision='single';
+if strcmp(precision,'single')
+    precision_cast=@(x) single(x)
+else
+    precision_cast=@(x) x
+end
+
 % Housing grid, from 0 to maxh. hprime=0 means renter; hprime>0 means owner.
 minh=0;
 maxh=5;
-h_grid=minh+(maxh-minh)*linspace(0,1,n_a(2))'.^2; % ^2 puts more points near minh
+h_grid=minh+(maxh-minh)*linspace(precision_cast(0),1,n_a(2))'.^2; % ^2 puts more points near minh
 
 % Asset grid. Includes a negative portion to allow mortgage borrowing.
 % The minimum possible value of assets is -(1-gamma)*maxh (the maximum mortgage).
@@ -107,9 +114,9 @@ minassets=-(1-Params.gamma)*maxh;
 maxassets=10;
 % Negative part of the grid: evenly spaced from minassets up to 0.
 n_a_neg=round(0.1*n_a(1)); % roughly 10% of points in the negative range
-asset_grid_neg=linspace(minassets,0,n_a_neg)';
+asset_grid_neg=linspace(precision_cast(minassets),0,n_a_neg)';
 % Positive part of the grid (more points nearer 0, where the value fn is most curved).
-asset_grid_pos=maxassets*linspace(0,1,n_a(1)-n_a_neg+1)'.^3;
+asset_grid_pos=maxassets*linspace(precision_cast(0),1,n_a(1)-n_a_neg+1)'.^3;
 % Note: both contain zero, so omit it from asset_grid_neg before stacking
 asset_grid=[asset_grid_neg(1:end-1); asset_grid_pos];
 
@@ -117,9 +124,11 @@ asset_grid=[asset_grid_neg(1:end-1); asset_grid_pos];
 a_grid=[asset_grid; h_grid];
 
 % AR(1) process for z (labor productivity units)
-[z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z);
+farmertodaoptions.precision=precision;
+mcmomentsoptions.precision=precision;
+[z_grid,pi_z]=discretizeAR1_FarmerToda(0,Params.rho_z,Params.sigma_epsilon_z,n_z,farmertodaoptions);
 z_grid=exp(z_grid); % Take exponential of the grid
-[mean_z,~,~,~]=MarkovChainMoments(z_grid,pi_z); % Mean of the grid so as can normalise it
+[mean_z,~,~,~]=MarkovChainMoments(z_grid,pi_z,mcmomentsoptions); % Mean of the grid so as can normalise it
 z_grid=z_grid./mean_z; % Normalise the grid on z (so that the mean of z is 1)
 
 d_grid=[]; % No decision variables
@@ -127,8 +136,13 @@ d_grid=[]; % No decision variables
 %% Now, create the return function
 DiscountFactorParamNames={'beta','sj'};
 
-ReturnFn=@(aprime,hprime,a,h,z,w,r,p,sigma,theta,upsilon,gamma,phi,delta_o,agej,Jr,pension,kappa_j,wg1,wg2,wg3,beta,sj) ...
-    LifeCycleModel40_ReturnFn(aprime,hprime,a,h,z,w,r,p,sigma,theta,upsilon,gamma,phi,delta_o,agej,Jr,pension,kappa_j,wg1,wg2,wg3,beta,sj);
+if isUnderlyingType(a_grid,'single')
+    ReturnFn=@(aprime,hprime,a,h,z,w,r,p,sigma,theta,upsilon,gamma,phi,delta_o,agej,Jr,pension,kappa_j,wg1,wg2,wg3,beta,sj) ...
+        LifeCycleModel40_ReturnFn_single(aprime,hprime,a,h,z,w,r,p,sigma,theta,upsilon,gamma,phi,delta_o,agej,Jr,pension,kappa_j,wg1,wg2,wg3,beta,sj);
+else
+    ReturnFn=@(aprime,hprime,a,h,z,w,r,p,sigma,theta,upsilon,gamma,phi,delta_o,agej,Jr,pension,kappa_j,wg1,wg2,wg3,beta,sj) ...
+        LifeCycleModel40_ReturnFn(aprime,hprime,a,h,z,w,r,p,sigma,theta,upsilon,gamma,phi,delta_o,agej,Jr,pension,kappa_j,wg1,wg2,wg3,beta,sj);
+end
 % (aprime,hprime,a,h,z,...): two next-period endogenous states, then two current
 % endogenous states, then the exogenous state z, then parameters.
 
@@ -149,7 +163,7 @@ vftime=toc
 
 %% Initial distribution of agents at birth (j=1)
 % All agents are born with zero assets and zero housing (so they are renters at j=1).
-jequaloneDist=zeros([n_a,n_z],'gpuArray');
+jequaloneDist=zeros([n_a,n_z],precision,'gpuArray');
 [~,zeroassetindex]=min(abs(asset_grid));
 jequaloneDist(zeroassetindex,1,floor((n_z+1)/2))=1; % zero assets, zero housing, median z
 
@@ -171,10 +185,17 @@ FnsToEvaluate.housing=@(aprime,hprime,a,h,z) h; % current housing stock
 FnsToEvaluate.homeownership=@(aprime,hprime,a,h,z) (hprime>0); % =1 if owner next period, =0 if renter
 FnsToEvaluate.totalwealth=@(aprime,hprime,a,h,z) a+h; % financial assets plus housing
 FnsToEvaluate.loantovalue=@(aprime,hprime,a,h,z) (aprime<0)*(hprime>0)*abs(aprime)/max(hprime,eps); % LTV ratio (only for borrowers)
-FnsToEvaluate.consumption=@(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j) ...
-    LifeCycleModel40_ConsumptionFn(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j);
-FnsToEvaluate.housingservices=@(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j) ...
-    LifeCycleModel40_HousingServicesFn(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j);
+if isUnderlyingType(a_grid,'single')
+    FnsToEvaluate.consumption=@(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j) ...
+        LifeCycleModel40_ConsumptionFn_single(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j);
+    FnsToEvaluate.housingservices=@(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j) ...
+        LifeCycleModel40_HousingServicesFn_single(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j);
+else
+    FnsToEvaluate.consumption=@(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j) ...
+        LifeCycleModel40_ConsumptionFn(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j);
+    FnsToEvaluate.housingservices=@(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j) ...
+        LifeCycleModel40_HousingServicesFn(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j);
+end
 
 %% Calculate the life-cycle profiles
 AgeConditionalStats=LifeCycleProfiles_FHorz_Case1(StationaryDist,Policy,FnsToEvaluate,Params,[],n_d,n_a,n_z,N_j,d_grid,a_grid,z_grid,simoptions);

--- a/Models40to44/LifeCycleModel40_ConsumptionFn_single.m
+++ b/Models40to44/LifeCycleModel40_ConsumptionFn_single.m
@@ -1,0 +1,35 @@
+function consumption=LifeCycleModel40_ConsumptionFn_single(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j)
+% Returns nondurable consumption c this period.
+
+single_1=single(1);
+
+% Income (working age vs retired)
+if agej<Jr
+    income=w*kappa_j*z;
+else
+    income=pension;
+end
+
+% Housing transactions cost (paid when h changes)
+if hprime==h
+    tau_hhprime=single(0);
+else
+    tau_hhprime=phi*h;
+end
+
+resources=income+(single_1+r)*a+(single_1-delta_o)*h-tau_hhprime;
+
+if hprime==0
+    %% Renter: split cspend into c and p*d analytically
+    cspend=resources-aprime; % cspend=c+p*d
+    if upsilon==0
+        consumption=theta*cspend;
+    else
+        consumption=cspend/(single_1+(p^(upsilon/(upsilon-single_1)))*((theta/(single_1-theta))^(single_1/(upsilon-single_1))));
+    end
+else
+    %% Owner: housing services come from hprime, so consumption is the residual
+    consumption=resources-aprime-hprime;
+end
+
+end

--- a/Models40to44/LifeCycleModel40_HousingServicesFn_single.m
+++ b/Models40to44/LifeCycleModel40_HousingServicesFn_single.m
@@ -1,0 +1,39 @@
+function housingservices=LifeCycleModel40_HousingServicesFn_single(aprime,hprime,a,h,z,w,r,p,theta,upsilon,phi,delta_o,agej,Jr,pension,kappa_j)
+% Returns housing services consumed this period:
+%   d for renters (chosen at price p; here solved analytically), hprime for owners.
+
+single_1=single(1);
+
+% Income (working age vs retired)
+if agej<Jr
+    income=w*kappa_j*z;
+else
+    income=pension;
+end
+
+% Housing transactions cost (paid when h changes)
+if hprime==h
+    tau_hhprime=single(0);
+else
+    tau_hhprime=phi*h;
+end
+
+resources=income+(single_1+r)*a+(single_1-delta_o)*h-tau_hhprime;
+
+if hprime==0
+    %% Renter
+    cspend=resources-aprime; % cspend=c+p*d
+    if upsilon==0
+        c=theta*cspend;
+        d=(single_1-theta)*cspend/p;
+    else
+        c=cspend/(single_1+(p^(upsilon/(upsilon-single_1)))*((theta/(single_1-theta))^(single_1/(upsilon-single_1))));
+        d=(cspend-c)/p;
+    end
+    housingservices=d;
+else
+    %% Owner
+    housingservices=hprime;
+end
+
+end

--- a/Models40to44/LifeCycleModel40_ReturnFn_single.m
+++ b/Models40to44/LifeCycleModel40_ReturnFn_single.m
@@ -1,0 +1,79 @@
+function F=LifeCycleModel40_ReturnFn_single(aprime,hprime,a,h,z,w,r,p,sigma,theta,upsilon,gamma,phi,delta_o,agej,Jr,pension,kappa_j,wg1,wg2,wg3,beta,sj)
+% Two next-period endogenous states (aprime,hprime), two current endogenous
+% states (a,h), one exogenous state (z), then parameters.
+
+F=single(-Inf);
+single_1=single(1);
+
+% Income (working age vs retired)
+if agej<Jr
+    income=w*kappa_j*z;
+else
+    income=pension;
+end
+
+% Housing transactions cost (paid when h changes; proportional to current house h)
+if hprime==h
+    tau_hhprime=single(0);
+else
+    tau_hhprime=phi*h;
+end
+
+% Resources available before purchasing new house and choosing aprime
+resources=income+(single_1+r)*a+(single_1-delta_o)*h-tau_hhprime;
+
+if hprime==0
+    %% Renter: chooses housing services d at price p (solved analytically below)
+    cspend=resources-aprime; % cspend=c+p*d
+    if cspend>0
+        % Analytic split of cspend into c and p*d from the CES first-order
+        % condition with budget c+p*d=cspend.
+        if upsilon==0
+            % Cobb-Douglas limit
+            c=theta*cspend;
+            d=(single_1-theta)*cspend/p;
+        else
+            c=cspend/(single_1+(p^(upsilon/(upsilon-single_1)))*((theta/(single_1-theta))^(single_1/(upsilon-single_1))));
+            d=(cspend-c)/p;
+        end
+        if c>0 && d>0
+            if upsilon==0
+                uinner=(c^theta)*(d^(single_1-theta));
+            else
+                uinner=(theta*(c^upsilon)+(single_1-theta)*(d^upsilon))^(single_1/upsilon);
+            end
+            F=(uinner^(single_1-sigma))/(single_1-sigma);
+        end
+    end
+    % Renter cannot borrow
+    if aprime<0
+        F=single(-Inf);
+    end
+else
+    %% Owner: housing services equal to the size of the house, hprime
+    c=resources-aprime-hprime;
+    if c>0
+        if upsilon==0
+            uinner=(c^theta)*(hprime^(single_1-theta));
+        else
+            uinner=(theta*(c^upsilon)+(single_1-theta)*(hprime^upsilon))^(single_1/upsilon);
+        end
+        F=(uinner^(single_1-sigma))/(single_1-sigma);
+    end
+    % Collateral constraint: mortgage cannot exceed (1-gamma) of the house value
+    if aprime<-(single_1-gamma)*hprime
+        F=single(-Inf);
+    end
+end
+
+% Warm glow of bequest (only near end of life), on terminal financial+housing wealth
+if agej>=Jr+10
+    bequest=aprime+(single_1-delta_o)*hprime;
+    if bequest>-wg2 % keep argument of (1+bequest/wg2) positive
+        warmglow=wg1*((single_1+bequest/wg2)^(single_1-wg3))/(single_1-wg3);
+        warmglow=beta*(single_1-sj)*warmglow; % only get warm glow next period if die
+        F=F+warmglow;
+    end
+end
+
+end


### PR DESCRIPTION
Implement a single-precision floating point version of LifeCycleModel1_ReturnFn.

Alas, MATLAB does not allow calling `isa(X, 'single')` inside `arrayfun`, and it breaks out `issingle` into Simulink and other non-Core add-ons.  Thus, it is not possible to test within the return function whether it should use double or single precision.